### PR TITLE
Reduce file format options to `xls` only for attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # DTS' Maximo & Geo Integration
+
+Currently, this is handled by an ETL which runs in Airflow. For more details, see the [ETL README](etl/parse_email_save_attachment/README.md).

--- a/etl/parse_email_save_attachment/parse_messages.py
+++ b/etl/parse_email_save_attachment/parse_messages.py
@@ -31,7 +31,7 @@ def get_most_recent_file(bucket_name, prefix):
     str: The key (path) of the most recent file. If no files are found, it returns a message.
     """
     s3 = boto3.client("s3")
-    paginator = s3.get_paginator('list_objects_v2')
+    paginator = s3.get_paginator("list_objects_v2")
 
     files = []
     for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
@@ -39,7 +39,9 @@ def get_most_recent_file(bucket_name, prefix):
             files.extend(page["Contents"])
 
     if not files:
-        raise FileNotFoundError("No files found in the bucket with the specified prefix.")
+        raise FileNotFoundError(
+            "No files found in the bucket with the specified prefix."
+        )
 
     # Sort the files by last modified date
     files = sorted(files, key=itemgetter("LastModified"), reverse=True)
@@ -47,7 +49,6 @@ def get_most_recent_file(bucket_name, prefix):
     # Get the most recent file
     most_recent_file = files[0]
     return most_recent_file["Key"]
-
 
 
 def get_file_content(bucket_name, file_key):
@@ -81,13 +82,14 @@ def get_file_content(bucket_name, file_key):
 
     return content, sha256_hash
 
+
 def parse_email_from_s3(email_content):
     """
     Parse an email from S3 and check specific headers.
 
     This function decodes the email content, checks specific headers against expected values
-    to help validate the sender's identity, and saves any attachments to a 
-    temporary directory. If any of the headers do not meet the expected values, it prints 
+    to help validate the sender's identity, and saves any attachments to a
+    temporary directory. If any of the headers do not meet the expected values, it prints
     a message and quits.
 
     Parameters:
@@ -103,17 +105,19 @@ def parse_email_from_s3(email_content):
 
     # List of headers to check
     headers_to_check = {
-        'X-SES-Spam-Verdict': 'PASS',
-        'X-SES-Virus-Verdict': 'PASS',
-        'Received-SPF': 'pass',
-        'X-OriginatorOrg': 'austintexas.gov'
+        "X-SES-Spam-Verdict": "PASS",
+        "X-SES-Virus-Verdict": "PASS",
+        "Received-SPF": "pass",
+        "X-OriginatorOrg": "austintexas.gov",
     }
 
     # Check the specified email headers
     for header, expected_value in headers_to_check.items():
         actual_value = parsed_email.get(header)
         if actual_value is None or expected_value not in actual_value:
-            print(f"Email validation condition not met: {header} is {actual_value}. Expected: {expected_value}")
+            print(
+                f"Email validation condition not met: {header} is {actual_value}. Expected: {expected_value}"
+            )
             quit()
 
     # Create a temporary directory to store attachments
@@ -196,7 +200,7 @@ def check_if_hash_has_been_seen(hash, bucket, prefix):
 
     This function lists all the objects in the specified S3 bucket and prefix,
     and checks if the first 8 characters of the hash are in the name of any of the objects.
-    If they are, it prints a message and returns True. If not, it returns False. The result 
+    If they are, it prints a message and returns True. If not, it returns False. The result
     of this function are used to pick if the program exists early or continues.
 
     Parameters:
@@ -208,18 +212,21 @@ def check_if_hash_has_been_seen(hash, bucket, prefix):
     bool: True if the hash has been seen before, False otherwise.
     """
     s3 = boto3.client("s3")
-    paginator = s3.get_paginator('list_objects_v2')
+    paginator = s3.get_paginator("list_objects_v2")
     short_hash = hash[:8]  # Only use the first 8 characters of the hash
 
     for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
         if "Contents" in page:
             for obj in page["Contents"]:
                 if short_hash in obj["Key"]:
-                    print(f"Hash {short_hash} has been seen before in file {obj['Key']}")
+                    print(
+                        f"Hash {short_hash} has been seen before in file {obj['Key']}"
+                    )
                     return True
 
     print(f"Hash {short_hash} has not been seen before.")
     return False
+
 
 def main():
     bucket = "emergency-mgmt-recd-data"

--- a/etl/parse_email_save_attachment/parse_messages.py
+++ b/etl/parse_email_save_attachment/parse_messages.py
@@ -108,7 +108,7 @@ def parse_email_from_s3(email_content):
         "X-SES-Spam-Verdict": "PASS",
         "X-SES-Virus-Verdict": "PASS",
         "Received-SPF": "pass",
-        "X-OriginatorOrg": "austintexas.gov",
+        # "X-OriginatorOrg": "austintexas.gov",
     }
 
     # Check the specified email headers

--- a/etl/parse_email_save_attachment/parse_messages.py
+++ b/etl/parse_email_save_attachment/parse_messages.py
@@ -108,7 +108,6 @@ def parse_email_from_s3(email_content):
         "X-SES-Spam-Verdict": "PASS",
         "X-SES-Virus-Verdict": "PASS",
         "Received-SPF": "pass",
-        # "X-OriginatorOrg": "austintexas.gov",
     }
 
     # Check the specified email headers

--- a/etl/parse_email_save_attachment/parse_messages.py
+++ b/etl/parse_email_save_attachment/parse_messages.py
@@ -119,7 +119,6 @@ def parse_email_from_s3(email_content):
                 f"Email validation condition not met: {header} is {actual_value}. Expected: {expected_value}"
             )
             quit()
-
     # Create a temporary directory to store attachments
     temp_dir = tempfile.mkdtemp()
     if parsed_email.is_multipart():

--- a/etl/parse_email_save_attachment/parse_messages.py
+++ b/etl/parse_email_save_attachment/parse_messages.py
@@ -142,7 +142,7 @@ def upload_attachments_to_s3(bucket, prefix, location, hash):
 
     This function creates a new folder in the S3 bucket with the current date, time, and hash.
     It then uploads all the files in the specified location to this new folder. If there are any
-    XLSX files in the location, it takes the alphabetically first one, deletes any existing
+    XLS files in the location, it takes the alphabetically first one, deletes any existing
     "most recent data" files in the S3 bucket, and uploads this file as the new "most recent data" file.
 
     Parameters:
@@ -160,16 +160,16 @@ def upload_attachments_to_s3(bucket, prefix, location, hash):
     folder_name = datetime.now(pytz.utc).strftime("%Y%m%d-%H%M%S_UTC") + "-" + hash[:8]
     new_prefix = os.path.join(prefix, folder_name)
 
-    # List all XLSX files in the location
-    xlsx_files = glob.glob(os.path.join(location, "*.xlsx"))
-    data_files = sorted(xlsx_files)
+    # List all XLS files in the location
+    xls_files = glob.glob(os.path.join(location, "*.xls"))
+    data_files = sorted(xls_files)
 
     if data_files:
-        # Take the alphabetically first XLSX file
+        # Take the alphabetically first XLS file
         data_file = data_files[0]
 
         # Create a new key for the data file
-        data_key = os.path.join("attachments", "most_recent_data.xlsx")
+        data_key = os.path.join("attachments", "most_recent_data.xls")
 
         # Delete all existing "most recent data" files
         for obj in s3.Bucket(bucket).objects.filter(

--- a/etl/parse_email_save_attachment/parse_messages.py
+++ b/etl/parse_email_save_attachment/parse_messages.py
@@ -142,7 +142,7 @@ def upload_attachments_to_s3(bucket, prefix, location, hash):
 
     This function creates a new folder in the S3 bucket with the current date, time, and hash.
     It then uploads all the files in the specified location to this new folder. If there are any
-    CSV or XLSX files in the location, it takes the alphabetically first one, deletes any existing
+    XLSX files in the location, it takes the alphabetically first one, deletes any existing
     "most recent data" files in the S3 bucket, and uploads this file as the new "most recent data" file.
 
     Parameters:
@@ -160,18 +160,16 @@ def upload_attachments_to_s3(bucket, prefix, location, hash):
     folder_name = datetime.now(pytz.utc).strftime("%Y%m%d-%H%M%S_UTC") + "-" + hash[:8]
     new_prefix = os.path.join(prefix, folder_name)
 
-    # List all files in the location
-    csv_files = glob.glob(os.path.join(location, "*.csv"))
+    # List all XLSX files in the location
     xlsx_files = glob.glob(os.path.join(location, "*.xlsx"))
-    data_files = sorted(csv_files + xlsx_files)
+    data_files = sorted(xlsx_files)
 
     if data_files:
-        # Take the alphabetically first CSV or XLSX file
+        # Take the alphabetically first XLSX file
         data_file = data_files[0]
-        file_extension = os.path.splitext(data_file)[1]
 
         # Create a new key for the data file
-        data_key = os.path.join("attachments", f"most_recent_data{file_extension}")
+        data_key = os.path.join("attachments", "most_recent_data.xlsx")
 
         # Delete all existing "most recent data" files
         for obj in s3.Bucket(bucket).objects.filter(

--- a/etl/parse_email_save_attachment/parse_messages.py
+++ b/etl/parse_email_save_attachment/parse_messages.py
@@ -64,7 +64,7 @@ def get_file_content(bucket_name, file_key):
 
     Returns:
     tuple: A tuple where the first element is the content of the file as a string,
-           and the second element is the SHA256 hash of the content.
+        and the second element is the SHA256 hash of the content.
     """
     s3 = boto3.client("s3")
 


### PR DESCRIPTION
## Intent

This PR hopes to close https://github.com/cityofaustin/atd-data-tech/issues/20248. 

The intent of this PR is to remove the concept of finding a CSV or XLSX file and simply expect a XLS file. 

## 🤦 re Maximo and file formats

It is confounding to me that Maximo is emitting an XLS file, which was deprecated in 2007, almost 20 years ago, to the XLSX format but here we are. XLSX is really just zipped up XML, so it's not like it's some wacky binary format either .. 

Additionally, modern Excel will issue a warning about the XLS file being corrupted in some way, but it doesn't give enough detail to even start to figure out what's wrong with it upstream in Maximo. Anyway - they send a file with a XLS extension, so we grab the file and write it to S3. It's outside the scope of our program to inspect that file in any way. 

## Testing

* `cd` into the directory containing the ETL
* Create or confirm you have an `env` file with 3 entries, as follows. Look in 1PW for `Maximo Geo Integrations`.

```
AWS_ACCESS_KEY_ID=<key>
AWS_SECRET_ACCESS_KEY=<secret key>
AWS_DEFAULT_REGION=us-east-1
```

* `docker compose build --no-cache` to build it anew
* `docker compose run parse-email`
* Confirm that `s3://emergency-mgmt-recd-data/attachments/most_recent_data.xls` exists and has a timestamp appropriate to when you tested this. 
  * One important caveat -- the program will detect if it's already seen an email & attachment and won't overwrite it if it's in place. So, two folks testing this concurrently -- the second person will get a non-op. I believe a new email is sent from Maximo at the top of the hour.
* Open up the file if you want, but you're now outside of this program's scope -- but feel free!