### PR TITLE
Update CI to reflect the correct primary branch name

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -51,4 +51,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           context: etl/parse_email_save_attachment
           push: true
-          tags: atddocker/maximo-geo-emergency-mgmt:${{ github.ref == 'refs/heads/master' && 'production' || 'latest' }}
+          tags: atddocker/maximo-geo-emergency-mgmt:${{ github.ref == 'refs/heads/main' && 'production' || 'latest' }}


### PR DESCRIPTION
There's no issue related to this. I checked on the deployment of the branch I merged this morning, and I observed that `:latest` had built, but not `:production`. This corrects the underlying problem.

I suggest that a review of the code is adequate in lieu of testing, but please feel free to inspect it in any way you wish.